### PR TITLE
Tag built images w/ internal build timestamp

### DIFF
--- a/.tekton/cntrtest-pull-request.yaml
+++ b/.tekton/cntrtest-pull-request.yaml
@@ -340,8 +340,10 @@ spec:
         params:
           - name: IMAGE
             value: $(tasks.build-container.results.IMAGE_URL)
+          - name: ADDITIONAL_TAGS
+            value: [$(tasks.extract-tag.results.buildtime)]
         runAfter:
-          - build-container
+          - extract-tag
         taskRef:
           params:
             - name: name

--- a/.tekton/cntrtest-push.yaml
+++ b/.tekton/cntrtest-push.yaml
@@ -337,8 +337,10 @@ spec:
         params:
           - name: IMAGE
             value: $(tasks.build-container.results.IMAGE_URL)
+          - name: ADDITIONAL_TAGS
+            value: [$(tasks.extract-tag.results.buildtime)]
         runAfter:
-          - build-container
+          - extract-tag
         taskRef:
           params:
             - name: name

--- a/Containerfile
+++ b/Containerfile
@@ -1,2 +1,2 @@
 FROM registry.access.redhat.com/ubi8/ubi
-RUN date -u --iso-8601=seconds > /root/buildtime
+RUN date -u --iso-8601=seconds | tr ":" "." | cut -d+ -f1 > /root/buildtime


### PR DESCRIPTION
This simulates tagging an image based on the output of running a command at build time from within the image.